### PR TITLE
v1.3.0 +semvar:minor

### DIFF
--- a/.github/workflows/PR-checks.yaml
+++ b/.github/workflows/PR-checks.yaml
@@ -29,7 +29,5 @@ jobs:
     - name: Build example project
       run: make build-example
     
-    - name: Run integration tests (example project)
-      run: |
-        ExampleConsole/bin/Debug/net9.0/ExampleConsole --Target target -v 15
-        ExampleConsole/bin/Debug/net9.0/ExampleConsole --Target target --Level Level3
+    - name: smoke test
+      run: make smoke-test

--- a/.github/workflows/main-build-and-tag.yaml
+++ b/.github/workflows/main-build-and-tag.yaml
@@ -35,6 +35,9 @@ jobs:
 
     - name: create release
       run: make release
+    
+    - name: smoke test
+      run: make smoke-test
       
     - name: Push changes and tags
       run: |

--- a/ArgumentParser.Analyzer/AnalyzerReleases.Shipped.md
+++ b/ArgumentParser.Analyzer/AnalyzerReleases.Shipped.md
@@ -1,4 +1,4 @@
-## Release 1.1.1
+## Release 1.3.0
 
 ### New Rules
 

--- a/ArgumentParser.Analyzer/AnalyzerReleases.Shipped.md
+++ b/ArgumentParser.Analyzer/AnalyzerReleases.Shipped.md
@@ -16,4 +16,4 @@ ARG009 | GenerationOptions | Error | HelpText property is missing but argument h
 ARG010 | GenerationOptions | Error | HelpText property is missing but display help on error handler is generated.
 ARG011 | GenerationOptions | Error | DisplayHelp property specified but generator is supplying it.
 ARG012 | GenerationOptions | Error | HelpText const string specified but generator is supplying it.
-ARG013 | AttributeDeclaration | Error | Flag attributes should only be applied to boolean properties.
+ARG013 | AttributeDeclaration | Error | Flag attributes should only be applied to boolean or enum properties.

--- a/ArgumentParser.Analyzer/AnalyzerReleases.UnShipped.md
+++ b/ArgumentParser.Analyzer/AnalyzerReleases.UnShipped.md
@@ -1,4 +1,4 @@
-## Release 1.2.0
+## Release 1.3.0
 
 ### New Rules
 

--- a/ArgumentParser.Analyzer/AnalyzerReleases.UnShipped.md
+++ b/ArgumentParser.Analyzer/AnalyzerReleases.UnShipped.md
@@ -4,4 +4,3 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-ARG013 | AttributeDeclaration | Error | Flag attributes should only be applied to boolean or enum properties.

--- a/ArgumentParser.Analyzer/CodeProviders/AssemblyVersionProvider.cs
+++ b/ArgumentParser.Analyzer/CodeProviders/AssemblyVersionProvider.cs
@@ -10,5 +10,5 @@ public static class AssemblyVersionProvider
 	/// The fullsemver version of the assembly.
 	/// Updated automatically by the build pipeline.
 	/// </summary>
-	public const string FullSemVer = "1.3.0-custom-types.1+3";
+	public const string FullSemVer = "1.3.0";
 }

--- a/ArgumentParser.Analyzer/CodeProviders/AssemblyVersionProvider.cs
+++ b/ArgumentParser.Analyzer/CodeProviders/AssemblyVersionProvider.cs
@@ -10,5 +10,5 @@ public static class AssemblyVersionProvider
 	/// The fullsemver version of the assembly.
 	/// Updated automatically by the build pipeline.
 	/// </summary>
-	public const string FullSemVer = "1.2.2";
+	public const string FullSemVer = "1.3.0-custom-types.1+3";
 }

--- a/ArgumentParser.Analyzer/CodeProviders/AssemblyVersionProvider.cs
+++ b/ArgumentParser.Analyzer/CodeProviders/AssemblyVersionProvider.cs
@@ -10,5 +10,5 @@ public static class AssemblyVersionProvider
 	/// The fullsemver version of the assembly.
 	/// Updated automatically by the build pipeline.
 	/// </summary>
-	public const string FullSemVer = "1.2.1-ci-versioning.2+2";
+	public const string FullSemVer = "1.2.2";
 }

--- a/ArgumentParser.Analyzer/SourceTextGenerator.cs
+++ b/ArgumentParser.Analyzer/SourceTextGenerator.cs
@@ -315,7 +315,7 @@ public class SourceTextGenerator : ISourceTextGenerator
 			return;
 		}
 		// otherwise just parse the value based on the (simple) type
-			var propertyType = propertyInfo.PropertyType;
+		var propertyType = propertyInfo.PropertyType;
 		switch (propertyType)
 		{
 			case "int":

--- a/ArgumentParser.Analyzer/SourceTextGenerator.cs
+++ b/ArgumentParser.Analyzer/SourceTextGenerator.cs
@@ -60,6 +60,7 @@ public class SourceTextGenerator : ISourceTextGenerator
 	{
 		var className = ClassDeclaration.Identifier.Text;
 		var namespaceName = Symbol.ContainingNamespace?.ToDisplayString();
+		var argumentParserVersion = AssemblyVersionProvider.FullSemVer;
 
 		using var writer = new IndentedTextWriter(new StringWriter());
 
@@ -71,7 +72,7 @@ public class SourceTextGenerator : ISourceTextGenerator
 			writer.WriteLine("{");
 			writer.Indent++;
 		}
-		writer.WriteLine("[System.CodeDom.Compiler.GeneratedCodeAttribute(\"ArgumentParser\", \"1.2.0\")]");
+		writer.WriteLine($"[System.CodeDom.Compiler.GeneratedCodeAttribute(\"ArgumentParser\", \"{argumentParserVersion}\")]");
 		writer.WriteLine($"public partial class {className}");
 		writer.WriteLine("{");
 		writer.Indent++;
@@ -295,8 +296,25 @@ public class SourceTextGenerator : ISourceTextGenerator
 			writer.WriteLine("}");
 			return;
 		}
+		// check if custom parse logic is specified
+		if (propertyInfo.HasParseMethod)
+		{
+			writer.WriteLine($"if (!{propertyInfo.PropertyType}.TryParse({localVariableName}.Value, out var parsedValue))");
+			writer.WriteLine("{");
+			writer.Indent++;
+			writer.WriteLine($"errors.Add(new ArgumentParser.InvalidArgumentValueException($\"Invalid value for {propertyName}: {{ {localVariableName}.Value }}\"));");
+			writer.Indent--;
+			writer.WriteLine("}");
+			writer.WriteLine("else");
+			writer.WriteLine("{");
+			writer.Indent++;
+			writer.WriteLine($"instance.{propertyName} = parsedValue;");
+			writer.Indent--;
+			writer.WriteLine("}");
+			return;
+		}
 		// otherwise just parse the value based on the (simple) type
-		var propertyType = propertyInfo.PropertyType;
+			var propertyType = propertyInfo.PropertyType;
 		switch (propertyType)
 		{
 			case "int":

--- a/ArgumentParser.Analyzer/SourceTextGenerator.cs
+++ b/ArgumentParser.Analyzer/SourceTextGenerator.cs
@@ -299,7 +299,8 @@ public class SourceTextGenerator : ISourceTextGenerator
 		// check if custom parse logic is specified
 		if (propertyInfo.HasParseMethod)
 		{
-			writer.WriteLine($"if (!{propertyInfo.PropertyType}.TryParse({localVariableName}.Value, out var parsedValue))");
+			var typeWithoutNullableIndicator = propertyInfo.PropertyType.Replace("?", "");
+			writer.WriteLine($"if (!{typeWithoutNullableIndicator}.{propertyInfo.ParseMethodName}({localVariableName}.Value, out var parsedValue))");
 			writer.WriteLine("{");
 			writer.Indent++;
 			writer.WriteLine($"errors.Add(new ArgumentParser.InvalidArgumentValueException($\"Invalid value for {propertyName}: {{ {localVariableName}.Value }}\"));");

--- a/ArgumentParser.Analyzer/Utilities/AttributeFactory.cs
+++ b/ArgumentParser.Analyzer/Utilities/AttributeFactory.cs
@@ -101,9 +101,13 @@ public class AttributeFactory
 		var flagAttributeData = _semanticModel.GetDeclaredSymbol(property)?.GetAttributes()
 		    .FirstOrDefault(attr => attr.AttributeClass?.ToDisplayString().Contains("FlagAttribute") == true);
 
+		var parsedWithMethodAttribute = _semanticModel.GetDeclaredSymbol(property)?.GetAttributes()
+			.FirstOrDefault(attr => attr.AttributeClass?.ToDisplayString().Contains("ParsedWithMethodAttribute") == true);
+
 		string shortName = string.Empty;
 		string longName = string.Empty;
 		string description = string.Empty;
+		string parsedWithMethod = string.Empty;
 
 		if (flagAttributeData != null)
 		{
@@ -139,6 +143,21 @@ public class AttributeFactory
 			}
 		}
 
+		if (parsedWithMethodAttribute != null)
+		{
+			if (parsedWithMethodAttribute.ConstructorArguments.Length > 0)
+			{
+				parsedWithMethod = parsedWithMethodAttribute.ConstructorArguments[0].Value?.ToString() ?? string.Empty;
+			}
+			foreach (var namedArg in parsedWithMethodAttribute.NamedArguments)
+			{
+				if (namedArg.Key == "methodName")
+				{
+					parsedWithMethod = namedArg.Value.Value?.ToString() ?? string.Empty;
+				}
+			}
+		}
+
 		var propertyName = property.Identifier.Text;
 		var propertySymbol = _semanticModel.GetDeclaredSymbol(property) as IPropertySymbol;
 		var propertyType = propertySymbol?.Type.ToDisplayString() ?? "string"; //default, no parsing
@@ -148,7 +167,8 @@ public class AttributeFactory
 			Attribute = new AttributeInfo(shortName, longName, description, false, -1),
 			PropertyName = propertyName,
 			PropertyType = propertyType,
-			PropertySymbol = propertySymbol
+			PropertySymbol = propertySymbol,
+			ParseMethodName = parsedWithMethod
 		};
 	}
 
@@ -162,10 +182,14 @@ public class AttributeFactory
 		var optionAttributeData = _semanticModel.GetDeclaredSymbol(property)?.GetAttributes()
 		    .FirstOrDefault(attr => attr.AttributeClass?.ToDisplayString().Contains("OptionAttribute") == true);
 
+		var parsedWithMethodAttribute = _semanticModel.GetDeclaredSymbol(property)?.GetAttributes()
+			.FirstOrDefault(attr => attr.AttributeClass?.ToDisplayString().Contains("ParsedWithMethodAttribute") == true);
+
 		string shortName = string.Empty;
 		string longName = string.Empty;
 		string description = string.Empty;
 		bool required = false;
+		string parsedWithMethod = string.Empty;
 
 		if (optionAttributeData != null)
 		{
@@ -217,6 +241,21 @@ public class AttributeFactory
 			}
 		}
 
+		if (parsedWithMethodAttribute != null)
+		{
+			if (parsedWithMethodAttribute.ConstructorArguments.Length > 0)
+			{
+				parsedWithMethod = parsedWithMethodAttribute.ConstructorArguments[0].Value?.ToString() ?? string.Empty;
+			}
+			foreach (var namedArg in parsedWithMethodAttribute.NamedArguments)
+			{
+				if (namedArg.Key == "methodName")
+				{
+					parsedWithMethod = namedArg.Value.Value?.ToString() ?? string.Empty;
+				}
+			}
+		}
+
 		var propertyName = property.Identifier.Text;
 		var propertySymbol = _semanticModel.GetDeclaredSymbol(property) as IPropertySymbol;
 		var propertyType = propertySymbol?.Type.ToDisplayString() ?? "string"; //default, no parsing
@@ -226,7 +265,8 @@ public class AttributeFactory
 			Attribute = new AttributeInfo(shortName, longName, description, required, -1),
 			PropertyName = propertyName,
 			PropertyType = propertyType,
-			PropertySymbol = propertySymbol
+			PropertySymbol = propertySymbol,
+			ParseMethodName = parsedWithMethod
 		};
 	}
 
@@ -240,9 +280,13 @@ public class AttributeFactory
 		var positionalAttributeData = _semanticModel.GetDeclaredSymbol(property)?.GetAttributes()
 		    .FirstOrDefault(attr => attr.AttributeClass?.ToDisplayString().Contains("PositionalAttribute") == true);
 
+		var parsedWithMethodAttribute = _semanticModel.GetDeclaredSymbol(property)?.GetAttributes()
+			.FirstOrDefault(attr => attr.AttributeClass?.ToDisplayString().Contains("ParsedWithMethodAttribute") == true);
+
 		string position = string.Empty;
 		string description = string.Empty;
 		bool required = false;
+		string parsedWithMethod = string.Empty;
 
 		if (positionalAttributeData != null)
 		{
@@ -286,6 +330,21 @@ public class AttributeFactory
 			}
 		}
 
+		if (parsedWithMethodAttribute != null)
+		{
+			if (parsedWithMethodAttribute.ConstructorArguments.Length > 0)
+			{
+				parsedWithMethod = parsedWithMethodAttribute.ConstructorArguments[0].Value?.ToString() ?? string.Empty;
+			}
+			foreach (var namedArg in parsedWithMethodAttribute.NamedArguments)
+			{
+				if (namedArg.Key == "methodName")
+				{
+					parsedWithMethod = namedArg.Value.Value?.ToString() ?? string.Empty;
+				}
+			}
+		}
+
 		var propertyName = property.Identifier.Text;
 		var propertySymbol = _semanticModel.GetDeclaredSymbol(property) as IPropertySymbol;
 		var propertyType = propertySymbol?.Type.ToDisplayString() ?? "string"; //default, no parsing
@@ -295,7 +354,8 @@ public class AttributeFactory
 			Attribute = new AttributeInfo("", "", description, required, int.Parse(position, CultureInfo.InvariantCulture)),
 			PropertyName = propertyName,
 			PropertyType = propertyType,
-			PropertySymbol = propertySymbol
+			PropertySymbol = propertySymbol,
+			ParseMethodName = parsedWithMethod
 		};
 	}
 }
@@ -324,6 +384,16 @@ public struct PropertyAndAttributeInfo : IEquatable<PropertyAndAttributeInfo>
 	/// The symbol representing the property.
 	/// </summary>
 	public IPropertySymbol? PropertySymbol { get; set; }
+
+	/// <summary>
+	/// The name of the method used for parsing the property value.
+	/// </summary>
+	public string ParseMethodName { get; set; }
+
+	/// <summary>
+	/// Indicates whether the property has a parse method defined.
+	/// </summary>
+	public readonly bool HasParseMethod { get => !string.IsNullOrEmpty(ParseMethodName); }
 
 	/// <summary>
 	/// Determines whether the current instance is equal to another object.

--- a/ArgumentParser.Analyzer/Validation.cs
+++ b/ArgumentParser.Analyzer/Validation.cs
@@ -181,8 +181,12 @@ public static class Validation
 			    position.Attribute.Position));
 		}
 
-		// Check for unsupported property types
-		var allProperties = options.Concat(positionals).Concat(flags).ToList();
+		// Check for unsupported property types (for properties that don't specify custom parsing)
+		var allProperties = options
+			.Concat(positionals)
+			.Concat(flags)
+			.Where(x => !x.HasParseMethod)
+			.ToList();
 		foreach (var prop in allProperties)
 		{
 			if (!IsSupportedPropertyType(prop))

--- a/ArgumentParser.Tests/Helpers/SourceCodeBuilder.cs
+++ b/ArgumentParser.Tests/Helpers/SourceCodeBuilder.cs
@@ -82,29 +82,41 @@ public class SourceCodeBuilder : IDisposable
 		return this;
 	}
 
-	public SourceCodeBuilder AddOptionParameter(PropertyAndAttributeInfo info, string? modifiers)
+	public SourceCodeBuilder AddOptionParameter(PropertyAndAttributeInfo info, string? modifiers, string? parseMethodName = null)
 	{
 		if (string.IsNullOrWhiteSpace(modifiers))
 			modifiers = "public";
+		if (!string.IsNullOrEmpty(parseMethodName))
+		{
+			classMembers.Add($"[ParsedWithMethod(\"{parseMethodName}\")]");
+		}
 		classMembers.Add($"[Option(\"{info.Attribute.ShortName}\", \"{info.Attribute.LongName}\", \"{info.Attribute.Description}\", {info.Attribute.Required.ToString().ToLower()})]");
 		classMembers.Add($"{modifiers} {info.PropertyType} {info.PropertyName} {{ get; set; }}");
 		classMembers.Add(Environment.NewLine);
 		return this;
 	}
 
-	public SourceCodeBuilder AddFlagParameter(PropertyAndAttributeInfo info, string? modifiers)
+	public SourceCodeBuilder AddFlagParameter(PropertyAndAttributeInfo info, string? modifiers, string? parseMethodName = null)
 	{
 		if (string.IsNullOrWhiteSpace(modifiers))
 			modifiers = "public";
+		if (!string.IsNullOrEmpty(parseMethodName))
+		{
+			classMembers.Add($"[ParsedWithMethod(\"{parseMethodName}\")]");
+		}
 		classMembers.Add($"[Flag(\"{info.Attribute.ShortName}\", \"{info.Attribute.LongName}\", \"{info.Attribute.Description}\")]");
 		classMembers.Add($"{modifiers} {info.PropertyType} {info.PropertyName} {{ get; set; }}");
 		classMembers.Add(Environment.NewLine);
 		return this;
 	}
-	public SourceCodeBuilder AddPositionalParameter(PropertyAndAttributeInfo info, string? modifiers)
+	public SourceCodeBuilder AddPositionalParameter(PropertyAndAttributeInfo info, string? modifiers, string? parseMethodName = null)
 	{
 		if (string.IsNullOrWhiteSpace(modifiers))
 			modifiers = "public";
+		if (!string.IsNullOrEmpty(parseMethodName))
+		{
+			classMembers.Add($"[ParsedWithMethod(\"{parseMethodName}\")]");
+		}
 		classMembers.Add($"[Positional({info.Attribute.Position}, \"{info.Attribute.Description}\", {info.Attribute.Required.ToString().ToLower()})]");
 		classMembers.Add($"{modifiers} {info.PropertyType} {info.PropertyName} {{ get; set; }}");
 		classMembers.Add(Environment.NewLine);

--- a/ArgumentParser.Tests/ParsedWithMethodTests.cs
+++ b/ArgumentParser.Tests/ParsedWithMethodTests.cs
@@ -1,0 +1,48 @@
+using Xunit;
+using ArgumentParser.Internal;
+using Microsoft.CodeAnalysis;
+
+namespace ArgumentParser.Tests
+{
+	/// <summary>
+	/// Example class to test the parsing of a custom class with a TryParse method.
+	/// </summary>
+	public class CustomClassWithTryParse()
+	{
+		public static bool TryParse(string input, out CustomClassWithTryParse result)
+		{
+			result = new CustomClassWithTryParse();
+			// Simulate parsing logic
+			return true;
+		}
+	}
+	public class ParsedWithMethodTests
+	{
+		private readonly SourceCodeBuilder builder = new();
+		public ParsedWithMethodTests()
+		{ }
+
+		[Fact]
+		public void Generator_HandlesCustomClassWithTryParse()
+		{
+			// Arrange
+			builder.AddImports(null)
+				.AddOptionParameter(new PropertyAndAttributeInfo
+				{
+					PropertyName = "CustomClass",
+					PropertyType = "CustomClassWithTryParse",
+					Attribute = new AttributeInfo("c", "Custom", "Custom class with TryParse", false, -1)
+				}, null, "TryParse");
+			var source = builder.ToString();
+
+			// Act
+			var (diagnostics, output) = TestHelper.GetGeneratedOutput(source);
+
+			// Assert
+			Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+			Assert.Contains("if (!ArgumentParser.Tests.CustomClassWithTryParse.TryParse", output);
+			Assert.Contains("out ArgumentParser.Tests.CustomClassWithTryParse parsedValue", output);
+			Assert.Contains("CustomClass = parsedValue", output);
+		}
+	}
+}

--- a/ArgumentParser.Tests/ParsedWithMethodTests.cs
+++ b/ArgumentParser.Tests/ParsedWithMethodTests.cs
@@ -41,7 +41,7 @@ namespace ArgumentParser.Tests
 			// Assert
 			Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
 			Assert.Contains("if (!ArgumentParser.Tests.CustomClassWithTryParse.TryParse", output);
-			Assert.Contains("out ArgumentParser.Tests.CustomClassWithTryParse parsedValue", output);
+			Assert.Contains("out var parsedValue", output);
 			Assert.Contains("CustomClass = parsedValue", output);
 		}
 	}

--- a/ArgumentParser/ArgumentParser.csproj
+++ b/ArgumentParser/ArgumentParser.csproj
@@ -17,7 +17,7 @@
 
     <!-- Package metadata -->
     <PackageId>Aot.ArgumentParser</PackageId>
-    <Version>1.2.2</Version>
+    <Version>1.3.0-custom-types.1+3</Version>
     <Authors>Jasper Ris</Authors>
     <Description>A source generator that generates an AoT-Friendly Parse method for an annotated class containing CLI arguments.</Description>
     <PackageTags>source-generator;analyzer;CLI;arguments;commandline;parser;AoT</PackageTags>

--- a/ArgumentParser/ArgumentParser.csproj
+++ b/ArgumentParser/ArgumentParser.csproj
@@ -17,7 +17,7 @@
 
     <!-- Package metadata -->
     <PackageId>Aot.ArgumentParser</PackageId>
-    <Version>1.2.1-ci-versioning.2+2</Version>
+    <Version>1.2.2</Version>
     <Authors>Jasper Ris</Authors>
     <Description>A source generator that generates an AoT-Friendly Parse method for an annotated class containing CLI arguments.</Description>
     <PackageTags>source-generator;analyzer;CLI;arguments;commandline;parser;AoT</PackageTags>

--- a/ArgumentParser/ArgumentParser.csproj
+++ b/ArgumentParser/ArgumentParser.csproj
@@ -17,7 +17,7 @@
 
     <!-- Package metadata -->
     <PackageId>Aot.ArgumentParser</PackageId>
-    <Version>1.3.0-custom-types.1+3</Version>
+    <Version>1.3.0</Version>
     <Authors>Jasper Ris</Authors>
     <Description>A source generator that generates an AoT-Friendly Parse method for an annotated class containing CLI arguments.</Description>
     <PackageTags>source-generator;analyzer;CLI;arguments;commandline;parser;AoT</PackageTags>

--- a/ArgumentParser/Attributes.cs
+++ b/ArgumentParser/Attributes.cs
@@ -80,7 +80,7 @@ namespace ArgumentParser
 
 			shortName ??= "";
 			longName ??= "";
-			if ( shortName.Length > 1)
+			if (shortName.Length > 1)
 				throw new ArgumentException("ShortName must be a single character.");
 
 			ShortName = shortName;
@@ -180,5 +180,28 @@ namespace ArgumentParser
 		/// Gets the description of the flag to be used in help text.
 		/// </summary>
 		public string Description { get; }
+	}
+
+	/// <summary>
+	/// This attribute indicates that the property type is parsed using a method with the specified name.
+	/// The method signature should be bool methodName(string input, out T value), i.e. TryParse style.
+	/// this method is expected to be a static method on the property's declaring type
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Property, Inherited = false)]
+	public sealed class ParsedWithMethodAttribute : Attribute
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ParsedWithMethodAttribute"/> class.
+		/// </summary>
+		/// <param name="methodName">The name of the method used to parse the arguments.</param>
+		public ParsedWithMethodAttribute(string methodName)
+		{
+			MethodName = methodName ?? throw new ArgumentNullException(nameof(methodName));
+		}
+
+		/// <summary>
+		/// Gets the name of the method used to parse the arguments.
+		/// </summary>
+		public string MethodName { get; }
 	}
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## UnReleased changes
 
+## v1.3.0
+### Added
+- Any type may now be used for a property if it is annotated with the ParsedWithMethod attribute
+  - To use this attribute, create a static (extension) method that follows the same signature as TryParse (bool TryParse(string input, out var result)).
+  - Initialize the ParsedWithMethodAttribute with the name of the method you created.
+  - The generate parse method will use the indicated method.
+### Improved
+- Added more make targets
+
 ## v1.2.0
 ### Added
 - All custom enum types are now allowed types. Parsing rules depend on whether the property is annotated with.

--- a/ExampleConsole/ExampleConsole.csproj
+++ b/ExampleConsole/ExampleConsole.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aot.ArgumentParser" Version="1.2.2" />
+    <PackageReference Include="Aot.ArgumentParser" Version="1.3.0-custom-types.1" />
   </ItemGroup>
 
 </Project>

--- a/ExampleConsole/ExampleConsole.csproj
+++ b/ExampleConsole/ExampleConsole.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aot.ArgumentParser" Version="1.2.0" />
+    <PackageReference Include="Aot.ArgumentParser" Version="1.2.2" />
   </ItemGroup>
 
 </Project>

--- a/ExampleConsole/ExampleConsole.csproj
+++ b/ExampleConsole/ExampleConsole.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aot.ArgumentParser" Version="1.3.0-custom-types.1" />
+    <PackageReference Include="Aot.ArgumentParser" Version="1.3.0" />
   </ItemGroup>
 
 </Project>

--- a/ExampleConsole/MyCommandLineArguments.cs
+++ b/ExampleConsole/MyCommandLineArguments.cs
@@ -61,6 +61,9 @@ public partial class MyCommandLineArguments
 	// Specifying the ParsedWithMethod attribute lets you specify your own parsing method
 	// This method should be a static (extension) method on the type you are using
 	// This disables type checking diagnostics
+	[ParsedWithMethod("ParseThis")]
+	[Positional(1, "Custom type")]
+	public MyVeryOwnType? MyVeryOwnType { get; set; }
 }
 
 public enum MyVeryOwnEnum
@@ -69,4 +72,19 @@ public enum MyVeryOwnEnum
 	Level1,
 	Level2,
 	Level3
+}
+
+public class MyVeryOwnType
+{
+	public static bool ParseThis(string input, out MyVeryOwnType result)
+	{
+		if (!string.IsNullOrEmpty(input))
+		{
+			result = new MyVeryOwnType();
+			return true;
+		}
+		result = null!;
+		return false;
+		
+	}
 }

--- a/ExampleConsole/MyCommandLineArguments.cs
+++ b/ExampleConsole/MyCommandLineArguments.cs
@@ -57,6 +57,10 @@ public partial class MyCommandLineArguments
 	// Combined with an option it lets you set a value based on a string
 	[Option(shortName: "", longName: "Level", description: "A level option with a long name")]
 	public MyVeryOwnEnum LevelOption { get; set; }
+
+	// Specifying the ParsedWithMethod attribute lets you specify your own parsing method
+	// This method should be a static (extension) method on the type you are using
+	// This disables type checking diagnostics
 }
 
 public enum MyVeryOwnEnum

--- a/ExampleConsole/Program.cs
+++ b/ExampleConsole/Program.cs
@@ -1,7 +1,5 @@
 ﻿using ExampleConsole;
 
-Console.WriteLine("Hello, World!");
-
 var (myArgs, err) = MyCommandLineArguments.Parse(args);
 Console.WriteLine($"Repeat: {myArgs.RepeatTimes}");
 Console.WriteLine($"Output: {myArgs.Output}");

--- a/Makefile
+++ b/Makefile
@@ -38,17 +38,20 @@ $(TESTPROJ_STAMP): $(TEST_SOURCES) $(ANALYZER_STAMP) | $(STAMP_DIR)
 
 help:
 	@echo "Makefile targets:"
-	@echo "  all                - Build everything and run tests"
-	@echo "  clean              - Clean the build artifacts"
-	@echo "  build-analyzer     - Build the ArgumentParser analyzer"
-	@echo "  restore-example    - Add locally built Aot.ArgumentParser package to ExampleConsole"
-	@echo "  build-example      - Build the ExampleConsole project"
-	@echo "  build-tests        - Build the ArgumentParser.Tests project"
-	@echo "  test               - Run the tests in ArgumentParser.Tests"
-	@echo "  coverage           - Generate a coverage report for ArgumentParser.Tests"
-	@echo "  set-version        - Set the version in the analyzer and example project based on git version"
-	@echo "  release            - Performs some checks and cuts a release"
-	@echo "  help               - Show this help message"
+	@echo "  all                    - Build everything and run tests"
+	@echo "  clean                  - Clean the build artifacts and coverage reports"
+	@echo "  build-analyzer         - Build the ArgumentParser analyzer (Release)"
+	@echo "  restore-example        - Add locally built Aot.ArgumentParser package to ExampleConsole"
+	@echo "  build-example          - Build the ExampleConsole project"
+	@echo "  build-tests            - Build the ArgumentParser.Tests project (Debug)"
+	@echo "  test                   - Run the tests in ArgumentParser.Tests with coverage"
+	@echo "  coverage               - Generate a coverage report for ArgumentParser.Tests"
+	@echo "  set-pre-release-version- Set the pre-release version in the analyzer and example project based on git version"
+	@echo "  set-version-stable     - Set the stable version in the analyzer and example project based on git version"
+	@echo "  pre-release            - Performs checks and cuts a pre-release (FullSemVer tag)"
+	@echo "  release-stable         - Performs checks and cuts a stable release (MajorMinorPatch tag)"
+	@echo "  smoke-test             - Run smoke tests on the ExampleConsole executable"
+	@echo "  help                   - Show this help message"
 
 all: build-analyzer build-example build-tests test
 
@@ -119,7 +122,7 @@ pre-release: clean set-version
 	@echo "Creating git tag..."
 	VERSION=$$(dotnet-gitversion | jq -r '.FullSemVer'); \
 	echo "Enter tag message for v$$VERSION (press Enter to start editor):"; \
-	git tag -a "v$$VERSION" -m "$$(read message; echo $$message)"; \
+	git tag -a "v$$VERSION" -m "Automated build for $$VERSION"
 	@echo "Release $$VERSION completed successfully."
 	@echo "Remember to push the tag with: git push origin v$$VERSION"
 

--- a/Makefile
+++ b/Makefile
@@ -98,25 +98,10 @@ set-version-stable:
 	sed -i 's|<Version>[^<]*</Version>|<Version>'"$$VERSION"'</Version>|' ArgumentParser/ArgumentParser.csproj
 	git commit -a --amend --no-edit
 
-pre-release: clean set-version
+pre-release: clean set-pre-release-version test smoke-test
 	@echo "Checking git working tree status..."
 	@if [ -n "$$(git status --porcelain)" ]; then \
 		echo "Error: Working tree is not clean. Please commit or stash changes before releasing."; \
-		exit 1; \
-	fi
-	@echo "Running tests..."
-	@if ! make test; then \
-		echo "Error: Tests failed. Aborting release."; \
-		exit 1; \
-	fi
-	@echo "Building example project..."
-	@if ! make build-example; then \
-		echo "Error: Example project build failed. Aborting release."; \
-		exit 1; \
-	fi
-	@echo "Running example console to verify it works..."
-	@if ! ExampleConsole/bin/Debug/net9.0/ExampleConsole --Help; then \
-		echo "Error: Example console execution failed. Aborting release."; \
 		exit 1; \
 	fi
 	@echo "Creating git tag..."
@@ -126,25 +111,10 @@ pre-release: clean set-version
 	@echo "Release $$VERSION completed successfully."
 	@echo "Remember to push the tag with: git push origin v$$VERSION"
 
-release-stable: clean set-version-stable
+release-stable: clean set-version-stable test smoke-test
 	@echo "Checking git working tree status..."
 	@if [ -n "$$(git status --porcelain)" ]; then \
 		echo "Error: Working tree is not clean. Please commit or stash changes before releasing."; \
-		exit 1; \
-	fi
-	@echo "Running tests..."
-	@if ! make test; then \
-		echo "Error: Tests failed. Aborting release."; \
-		exit 1; \
-	fi
-	@echo "Building example project..."
-	@if ! make build-example; then \
-		echo "Error: Example project build failed. Aborting release."; \
-		exit 1; \
-	fi
-	@echo "Running example console to verify it works..."
-	@if ! ExampleConsole/bin/Debug/net9.0/ExampleConsole --Help; then \
-		echo "Error: Example console execution failed. Aborting release."; \
 		exit 1; \
 	fi
 	@echo "Creating git tag..."

--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 # ArgumentParser
 Licensed under the Apache License, Version 2.0
 
+## Table of contents
+- [ArgumentParser](#argumentparser)
+	- [Table of contents](#table-of-contents)
+	- [About](#about)
+	- [Quickstart](#quickstart)
+		- [Overriding the default behaviour](#overriding-the-default-behaviour)
+		- [Supported types for argument properties](#supported-types-for-argument-properties)
+	- [Inspecting the generated code](#inspecting-the-generated-code)
+	- [Default behaviour](#default-behaviour)
+	- [Diagnostics and Errors](#diagnostics-and-errors)
+	- [Known bugs (past and present)](#known-bugs-past-and-present)
+- [Development](#development)
+	- [building and testing locally](#building-and-testing-locally)
+	- [creating a release](#creating-a-release)
+
 ## About
 ArgumentParser provides functionality to parse commandline arguments without the use of Reflection. It is therefore compatible with AOT publishing.
 
@@ -311,3 +326,20 @@ v1.1.0
 
 v1.0.0:
 	- AggregateException is always thrown when any parse error is encountered
+
+# Development
+The project comes with a makefile that should cover most typical needs during the development cycle.
+
+## building and testing locally
+run ```make build-analyzer``` to generate the nuget package locally
+run ```make build-example``` to build the example project
+run ```make test``` and ```make smoke-test``` to run unit testing and smoke testing, respectively. Smoke testing runs the example project
+
+## creating a release
+For a release, the version of the final nuget package, the version specified in the GeneratedCodeAttribute, and the git tag should all match.
+
+The easiest way to do this is to install dotnet-gitversion and run ```make set-pre-release-version``` or ```make set-version-stable```.
+The first creates a pre-release tag and updates the corresponding files in the project. The second creates a major.minor.patch release tag and also updates files. Both targets amend the latest commit to include these changes in the source tree.
+
+```make pre-release``` and ```make release-stable``` respectively create a prerelease and a stable release, along with the required git tag.
+Stable releases should only be created from the main branch.


### PR DESCRIPTION
## v1.3.0
### Added
- Any type may now be used for a property if it is annotated with the ParsedWithMethod attribute
  - To use this attribute, create a static (extension) method that follows the same signature as TryParse (bool TryParse(string input, out var result)).
  - Initialize the ParsedWithMethodAttribute with the name of the method you created.
  - The generate parse method will use the indicated method.
### Improved
- Added more make targets